### PR TITLE
fix "This block declaration is not a prototype" warnings

### DIFF
--- a/RMStore/Optional/RMStoreAppReceiptVerifier.m
+++ b/RMStore/Optional/RMStoreAppReceiptVerifier.m
@@ -24,7 +24,7 @@
 @implementation RMStoreAppReceiptVerifier
 
 - (void)verifyTransaction:(SKPaymentTransaction*)transaction
-                           success:(void (^)())successBlock
+                           success:(void (^)(void))successBlock
                            failure:(void (^)(NSError *error))failureBlock
 {
     RMAppReceipt *receipt = [RMAppReceipt bundleReceipt];
@@ -87,7 +87,7 @@
 
 - (BOOL)verifyTransaction:(SKPaymentTransaction*)transaction
                 inReceipt:(RMAppReceipt*)receipt
-                           success:(void (^)())successBlock
+                           success:(void (^)(void))successBlock
                            failure:(void (^)(NSError *error))failureBlock
 {
     const BOOL receiptVerified = [self verifyAppReceipt:receipt];

--- a/RMStore/Optional/RMStoreTransactionReceiptVerifier.m
+++ b/RMStore/Optional/RMStoreTransactionReceiptVerifier.m
@@ -94,7 +94,7 @@ static const char _base64EncodingTable[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh
 @implementation RMStoreTransactionReceiptVerifier
 
 - (void)verifyTransaction:(SKPaymentTransaction*)transaction
-                           success:(void (^)())successBlock
+                           success:(void (^)(void))successBlock
                            failure:(void (^)(NSError *error))failureBlock
 {    
     NSString *receipt = [transaction.transactionReceipt rm_stringByBase64Encoding];
@@ -129,7 +129,7 @@ static const char _base64EncodingTable[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh
 
 - (void)verifyRequestData:(NSData*)requestData
                       url:(NSString*)urlString
-                  success:(void (^)())successBlock
+                  success:(void (^)(void))successBlock
                   failure:(void (^)(NSError *error))failureBlock
 {
     NSURL *url = [NSURL URLWithString:urlString];

--- a/RMStore/RMStore.h
+++ b/RMStore/RMStore.h
@@ -138,7 +138,7 @@ extern NSInteger const RMStoreErrorCodeUnableToCompleteVerification;
  @param successBlock The block to be called if the refresh receipt request is sucessful. Can be `nil`.
  @param failureBlock The block to be called if the refresh receipt request fails. Can be `nil`.
  */
-- (void)refreshReceiptOnSuccess:(void (^)())successBlock
+- (void)refreshReceiptOnSuccess:(void (^)(void))successBlock
                         failure:(void (^)(NSError *error))failureBlock __attribute__((availability(ios,introduced=7.0)));
 
 ///---------------------------------------------
@@ -214,7 +214,7 @@ extern NSInteger const RMStoreErrorCodeUnableToCompleteVerification;
  @discussion Hosted content from Apple’s server (@c SKDownload) is handled automatically by RMStore.
  */
 - (void)downloadContentForTransaction:(SKPaymentTransaction*)transaction
-                              success:(void (^)())successBlock
+                              success:(void (^)(void))successBlock
                              progress:(void (^)(float progress))progressBlock
                               failure:(void (^)(NSError *error))failureBlock;
 
@@ -228,7 +228,7 @@ extern NSInteger const RMStoreErrorCodeUnableToCompleteVerification;
  @param failureBlock Called if the transaction failed verification. If verification could not be completed (e.g., due to connection issues), then error must be of code RMStoreErrorCodeUnableToCompleteVerification to prevent RMStore to finish the transaction. Must be called in the main queu.
  */
 - (void)verifyTransaction:(SKPaymentTransaction*)transaction
-                  success:(void (^)())successBlock
+                  success:(void (^)(void))successBlock
                   failure:(void (^)(NSError *error))failureBlock;
 
 @end
@@ -248,7 +248,7 @@ extern NSInteger const RMStoreErrorCodeUnableToCompleteVerification;
  @param failureBlock Called if the transaction failed to be processed. Must be called in the main queu.
  */
 - (void)processTransaction:(SKPaymentTransaction*)transaction
-                   success:(void(^)())successBlock
+                   success:(void (^)(void))successBlock
                    failure:(void (^)(NSError *error))failureBlock;
 
 @end

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -61,7 +61,7 @@ typedef void (^RMSKPaymentTransactionSuccessBlock)(SKPaymentTransaction *transac
 typedef void (^RMSKProductsRequestFailureBlock)(NSError *error);
 typedef void (^RMSKProductsRequestSuccessBlock)(NSArray *products, NSArray *invalidIdentifiers);
 typedef void (^RMStoreFailureBlock)(NSError *error);
-typedef void (^RMStoreSuccessBlock)();
+typedef void (^RMStoreSuccessBlock)(void);
 
 @implementation NSNotification(RMStore)
 

--- a/RMStoreTests/RMStoreTests.m
+++ b/RMStoreTests/RMStoreTests.m
@@ -1296,7 +1296,7 @@
 
 @implementation RMStoreContentDownloaderSuccess
 
-- (void)downloadContentForTransaction:(SKPaymentTransaction *)transaction success:(void (^)())successBlock progress:(void (^)(float))progressBlock failure:(void (^)(NSError *))failureBlock
+- (void)downloadContentForTransaction:(SKPaymentTransaction *)transaction success:(void (^)(void))successBlock progress:(void (^)(float))progressBlock failure:(void (^)(NSError *))failureBlock
 {
     if (successBlock) successBlock();
 }
@@ -1305,7 +1305,7 @@
 
 @implementation RMStoreContentDownloaderProgress
 
-- (void)downloadContentForTransaction:(SKPaymentTransaction *)transaction success:(void (^)())successBlock progress:(void (^)(float))progressBlock failure:(void (^)(NSError *))failureBlock
+- (void)downloadContentForTransaction:(SKPaymentTransaction *)transaction success:(void (^)(void))successBlock progress:(void (^)(float))progressBlock failure:(void (^)(NSError *))failureBlock
 {
     if (progressBlock) progressBlock(self.progress);
 }
@@ -1314,7 +1314,7 @@
 
 @implementation RMStoreContentDownloaderFailure
 
-- (void)downloadContentForTransaction:(SKPaymentTransaction *)transaction success:(void (^)())successBlock progress:(void (^)(float))progressBlock failure:(void (^)(NSError *))failureBlock
+- (void)downloadContentForTransaction:(SKPaymentTransaction *)transaction success:(void (^)(void))successBlock progress:(void (^)(float))progressBlock failure:(void (^)(NSError *))failureBlock
 {
     if (failureBlock) failureBlock(self.error);
 }
@@ -1323,7 +1323,7 @@
 
 @implementation RMStoreReceiptVerifierSuccess
 
-- (void)verifyTransaction:(SKPaymentTransaction *)transaction success:(void (^)())successBlock failure:(void (^)(NSError *))failureBlock
+- (void)verifyTransaction:(SKPaymentTransaction *)transaction success:(void (^)(void))successBlock failure:(void (^)(NSError *))failureBlock
 {
     if (successBlock) successBlock();
 }
@@ -1332,7 +1332,7 @@
 
 @implementation RMStoreReceiptVerifierFailure
 
-- (void)verifyTransaction:(SKPaymentTransaction *)transaction success:(void (^)())successBlock failure:(void (^)(NSError *))failureBlock
+- (void)verifyTransaction:(SKPaymentTransaction *)transaction success:(void (^)(void))successBlock failure:(void (^)(NSError *))failureBlock
 {
     if (failureBlock) failureBlock(nil);
 }
@@ -1341,7 +1341,7 @@
 
 @implementation RMStoreReceiptVerifierUnableToComplete
 
-- (void)verifyTransaction:(SKPaymentTransaction *)transaction success:(void (^)())successBlock failure:(void (^)(NSError *))failureBlock
+- (void)verifyTransaction:(SKPaymentTransaction *)transaction success:(void (^)(void))successBlock failure:(void (^)(NSError *))failureBlock
 {
     NSError *error = [NSError errorWithDomain:RMStoreErrorDomain code:RMStoreErrorCodeUnableToCompleteVerification userInfo:nil];
     if (failureBlock) failureBlock(error);


### PR DESCRIPTION
First, thanks for adding support for App Store Payments @sirnacnud 

This PR fixes a few `This block declaration is not a prototype` warnings. Linking to the master branch of your fork in the Podfile causes the the pod to get reinstalled on every `pod update`, which in turn causes warnings in our `RMStoreReceiptVerifier` implementation.

Merging this would help to get rid of the warnings until we are ready to remove RMStore...